### PR TITLE
Fix global parameters for custom blocks.

### DIFF
--- a/src/main/java/io/qameta/htmlelements/context/Context.java
+++ b/src/main/java/io/qameta/htmlelements/context/Context.java
@@ -59,11 +59,13 @@ public class Context {
         childContext.setParent(this);
         //extension
         getStore().get(PROPERTIES_KEY, Properties.class).ifPresent(properties -> {
-            Properties child = new Properties(properties);
+            Properties child = new Properties();
+            child.putAll(properties);
             childContext.getStore().put(PROPERTIES_KEY, child);
         });
         getStore().get(PARAMETERS_KEY, Properties.class).ifPresent(properties -> {
-            Properties child = new Properties(properties);
+            Properties child = new Properties();
+            child.putAll(properties);
             childContext.getStore().put(PARAMETERS_KEY, child);
         });
         getStore().get(LISTENERS_KEY, List.class).ifPresent(listeners -> {

--- a/src/test/java/io/qameta/htmlelements/GlobalParametersTest.java
+++ b/src/test/java/io/qameta/htmlelements/GlobalParametersTest.java
@@ -24,13 +24,18 @@ public class GlobalParametersTest {
         WebDriver driver = TestData.mockDriver();
         WebElement element = TestData.WebElementBuilder.mockWebElement().withDisplayed(true).build();
         when(driver.findElement(By.xpath("//div[@class='value']"))).thenReturn(element);
+        when(driver.findElement(By.xpath("//div[@class='simpleElement']"))).thenReturn(element);
+        when(element.findElement(By.xpath(".//div[@class='childElement']"))).thenReturn(element);
 
         WebPageFactory factory = new WebPageFactory()
-                .parameter("key", "value");
+                .parameter("key", "value")
+                .parameter("simple", "simpleElement")
+                .parameter("child", "childElement");
 
         SimplePage page = factory.get(driver, SimplePage.class);
         page.input().should(DisplayedMatcher.displayed());
-
+        page.simpleElement().should(DisplayedMatcher.displayed());
+        page.simpleElement().childElement().should(DisplayedMatcher.displayed());
     }
 
     public interface SimplePage extends WebPage {
@@ -38,8 +43,14 @@ public class GlobalParametersTest {
         @FindBy("//div[@class='{{ key }}']")
         HtmlElement input();
 
+        @FindBy("//div[@class='{{ simple }}']")
+        SimpleElement simpleElement();
     }
 
+    public interface SimpleElement extends HtmlElement {
 
+        @FindBy(".//div[@class='{{ child }}']")
+        HtmlElement childElement();
+    }
 
 }


### PR DESCRIPTION
Class Properties no have copying constructor like Collection.
For example:
```
Properties prop1 = new Properties(); // empty properties
prop1.setProperty("key", "value");
Properties prop2 = new Properties(prop1);
prop2.getProperty("key"); //return "value"
Properties prop3 = new Properties(prop2);
prop3.getProperty("key); //return null
```